### PR TITLE
Make stack traces work with the noConflict method of including jQuery

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='django-debug-toolbar-redis',
-    version='0.0.2',
+    version='0.0.3',
     description='Simple debug toolbar panel for Redis',
     #long_description=open('README.md').read(),
     author='Clement Nodet',


### PR DESCRIPTION
If you use this panel in the newest version of django debug toolbar then you'll not get stack traces :(
